### PR TITLE
Improve snake game visuals and add scoreboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + TS</title>
+    <title>Snake Game</title>
   </head>
   <body>
     <div id="app"></div>

--- a/src/gameLogic.ts
+++ b/src/gameLogic.ts
@@ -4,11 +4,18 @@ import { drawApple, drawSnake } from './drawFunctions';
 export function initializeGame() {
   const canvas = document.querySelector<HTMLCanvasElement>('#canvas')!;
   const ctx = canvas.getContext('2d')!;
+  const scoreboard = document.querySelector<HTMLDivElement>('#scoreboard')!;
+  const restartButton = document.querySelector<HTMLButtonElement>('#restart')!;
   const speed = 150;
   const pixelSize = 20;
   let keyPressed = false;
+  let highScore = parseInt(localStorage.getItem('highScore') ?? '0');
 
-  // Initial game state
+  restartButton.style.display = 'none';
+  restartButton.onclick = () => {
+    initializeGame();
+  };
+
   const snakePositions = [
     { x: 300, y: 300 },
     { x: 300 - pixelSize, y: 300 },
@@ -16,6 +23,17 @@ export function initializeGame() {
   ];
   let applePosition = { x: 100, y: 100 };
   let direction = 'up';
+
+  const updateScoreboard = () => {
+    const score = snakePositions.length - 3;
+    if (score > highScore) {
+      highScore = score;
+      localStorage.setItem('highScore', highScore.toString());
+    }
+    scoreboard.textContent = `Score: ${score} | High Score: ${highScore}`;
+  };
+
+  updateScoreboard();
 
   const eventListener = (event: KeyboardEvent) => {
     if (keyPressed) return;
@@ -73,7 +91,10 @@ export function initializeGame() {
     );
 
     if (colidedWithSelf || colidedWithWall) {
-      gameOver(ctx, snakePositions.length);
+      updateScoreboard();
+      window.removeEventListener('keydown', eventListener);
+      restartButton.style.display = 'block';
+      gameOver(ctx, snakePositions.length - 3);
       return;
     }
 
@@ -84,6 +105,7 @@ export function initializeGame() {
         y: Math.floor(Math.random() * canvas.height / pixelSize) * pixelSize,
       };
       snakePositions.push(snakePositions[snakePositions.length - 1]);
+      updateScoreboard();
     }
 
     // Clear canvas and draw
@@ -99,10 +121,10 @@ export function initializeGame() {
   gameLoop();
 }
 
-function gameOver(ctx: CanvasRenderingContext2D, snakeLength: number) {
+function gameOver(ctx: CanvasRenderingContext2D, score: number) {
   ctx.font = '30px Arial';
   ctx.fillStyle = 'black';
   ctx.textAlign = 'center';
   ctx.fillText('Game Over', ctx.canvas.width / 2, ctx.canvas.height / 2);
-  ctx.fillText(`Score: ${snakeLength}`, ctx.canvas.width / 2, ctx.canvas.height / 2 + 30);
+  ctx.fillText(`Score: ${score}`, ctx.canvas.width / 2, ctx.canvas.height / 2 + 30);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,11 @@ import './style.css'
 import { initializeGame } from './gameLogic'
 
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
-  <div>
-    <canvas style="border: 1px solid black; background: white" height="1000" width="1000" id="canvas"></canvas>
-  </div>
+  <h1>Snake</h1>
+  <div id="scoreboard"></div>
+  <canvas height="600" width="600" id="canvas"></canvas>
+  <button id="restart">Restart</button>
 `
 
 initializeGame()
+

--- a/src/style.css
+++ b/src/style.css
@@ -42,3 +42,19 @@ h1 {
   padding: 2rem;
   text-align: center;
 }
+
+canvas {
+  border: 2px solid #555;
+  background-color: white;
+}
+
+#scoreboard {
+  margin-bottom: 1rem;
+  color: #333;
+  font-size: 1.2rem;
+}
+
+#restart {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+}


### PR DESCRIPTION
## Summary
- show scoreboard and restart button in the UI
- track high score using local storage
- display game title in the page
- add styling for canvas and scoreboard

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f3d4adc58832bb87df5c4f18ce9e8